### PR TITLE
Sprinkle send request prints

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -500,29 +500,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "env_filter"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f2c92ceda6ceec50f43169f9ee8424fe2db276791afde7b2cd8bc084cb376ab"
-dependencies = [
- "log",
- "regex",
-]
-
-[[package]]
-name = "env_logger"
-version = "0.11.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e13fa619b91fb2381732789fc5de83b45675e882f66623b7d8cb4f643017018d"
-dependencies = [
- "anstream",
- "anstyle",
- "env_filter",
- "humantime",
- "log",
-]
-
-[[package]]
 name = "equivalent"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -875,7 +852,6 @@ name = "hickory-dns"
 version = "0.24.0"
 dependencies = [
  "clap",
- "env_logger",
  "futures-util",
  "hickory-client",
  "hickory-proto",
@@ -896,7 +872,6 @@ name = "hickory-integration"
 version = "0.24.0"
 dependencies = [
  "async-trait",
- "env_logger",
  "futures",
  "hickory-client",
  "hickory-proto",
@@ -1081,12 +1056,6 @@ dependencies = [
  "fnv",
  "itoa",
 ]
-
-[[package]]
-name = "humantime"
-version = "2.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
 name = "icu_collections"

--- a/bin/tests/server_harness/mut_message_client.rs
+++ b/bin/tests/server_harness/mut_message_client.rs
@@ -30,6 +30,7 @@ impl<C: ClientHandle + Unpin> DnsHandle for MutMessageHandle<C> {
 
     #[allow(unused_mut)]
     fn send<R: Into<DnsRequest> + Unpin>(&self, request: R) -> Self::Response {
+        tracing::debug!("Sending request");
         let mut request = request.into();
 
         #[cfg(feature = "dnssec")]

--- a/crates/client/src/client/async_client.rs
+++ b/crates/client/src/client/async_client.rs
@@ -148,7 +148,10 @@ impl DnsHandle for AsyncClient {
     type Error = ProtoError;
 
     fn send<R: Into<DnsRequest> + Unpin + Send + 'static>(&self, request: R) -> Self::Response {
-        self.exchange.send(request)
+        debug!("Sending dns request");
+        let res = self.exchange.send(request);
+        debug!("Dns response recieved");
+        res
     }
 
     fn is_using_edns(&self) -> bool {

--- a/crates/client/src/client/async_secure_client.rs
+++ b/crates/client/src/client/async_secure_client.rs
@@ -72,6 +72,7 @@ impl DnsHandle for AsyncDnssecClient {
     type Error = ProtoError;
 
     fn send<R: Into<DnsRequest> + Unpin + Send + 'static>(&self, request: R) -> Self::Response {
+        tracing::debug!("Sending request");
         self.client.send(request)
     }
 }

--- a/crates/client/src/client/client.rs
+++ b/crates/client/src/client/client.rs
@@ -99,6 +99,7 @@ pub trait Client {
         &self,
         msg: R,
     ) -> Vec<ClientResult<DnsResponse>> {
+        tracing::debug!("Sending request");
         let (client, runtime) = match self.spawn_client() {
             Ok(c_r) => c_r,
             Err(e) => return vec![Err(e)],

--- a/crates/proto/src/xfer/dns_exchange.rs
+++ b/crates/proto/src/xfer/dns_exchange.rs
@@ -108,6 +108,7 @@ impl DnsHandle for DnsExchange {
     type Error = ProtoError;
 
     fn send<R: Into<DnsRequest> + Unpin + Send + 'static>(&self, request: R) -> Self::Response {
+        tracing::debug!("Sending request");
         DnsExchangeSend {
             result: self.sender.send(request),
             _sender: self.sender.clone(), // TODO: this shouldn't be necessary, currently the presence of Senders is what allows the background to track current users, it generally is dropped right after send, this makes sure that there is at least one active after send

--- a/crates/proto/src/xfer/dns_handle.rs
+++ b/crates/proto/src/xfer/dns_handle.rs
@@ -65,7 +65,9 @@ pub trait DnsHandle: 'static + Clone + Send + Sync + Unpin {
     /// * `options` - options to use when constructing the message
     fn lookup(&self, query: Query, options: DnsRequestOptions) -> Self::Response {
         debug!("querying: {} {:?}", query.name(), query.query_type());
-        self.send(DnsRequest::new(build_message(query, options), options))
+        let r = self.send(DnsRequest::new(build_message(query, options), options));
+        tracing::debug!("lookup return");
+        r
     }
 }
 

--- a/crates/proto/src/xfer/dns_request.rs
+++ b/crates/proto/src/xfer/dns_request.rs
@@ -84,6 +84,7 @@ impl DerefMut for DnsRequest {
 
 impl From<Message> for DnsRequest {
     fn from(message: Message) -> Self {
+        tracing::debug!("Converting to DnsRequest");
         Self::new(message, DnsRequestOptions::default())
     }
 }

--- a/crates/proto/src/xfer/mod.rs
+++ b/crates/proto/src/xfer/mod.rs
@@ -168,6 +168,7 @@ impl DnsHandle for BufDnsRequestStreamHandle {
     type Error = ProtoError;
 
     fn send<R: Into<DnsRequest>>(&self, request: R) -> Self::Response {
+        tracing::debug!("Sending request");
         let request: DnsRequest = request.into();
         debug!(
             "enqueueing message:{}:{:?}",

--- a/crates/resolver/src/lookup.rs
+++ b/crates/resolver/src/lookup.rs
@@ -205,11 +205,14 @@ impl<P: ConnectionProvider> DnsHandle for LookupEither<P> {
     }
 
     fn send<R: Into<DnsRequest> + Unpin + Send + 'static>(&self, request: R) -> Self::Response {
-        match *self {
+        tracing::debug!("Sending request");
+        let r = match *self {
             Self::Retry(ref c) => c.send(request),
             #[cfg(feature = "dnssec")]
             Self::Secure(ref c) => c.send(request),
-        }
+        };
+        tracing::debug!("reply");
+        r
     }
 }
 

--- a/crates/resolver/src/name_server/connection_provider.rs
+++ b/crates/resolver/src/name_server/connection_provider.rs
@@ -244,6 +244,7 @@ impl DnsHandle for GenericConnection {
     type Error = ResolveError;
 
     fn send<R: Into<DnsRequest> + Unpin + Send + 'static>(&self, request: R) -> Self::Response {
+        tracing::debug!("Sending request");
         ConnectionResponse(self.0.send(request))
     }
 }

--- a/crates/resolver/src/name_server/name_server.rs
+++ b/crates/resolver/src/name_server/name_server.rs
@@ -185,6 +185,7 @@ where
     // TODO: there needs to be some way of customizing the connection based on EDNS options from the server side...
     fn send<R: Into<DnsRequest> + Unpin + Send + 'static>(&self, request: R) -> Self::Response {
         let this = self.clone();
+        tracing::debug!("Sending request");
         // if state is failed, return future::err(), unless retry delay expired..
         Box::pin(once(this.inner_send(request)))
     }

--- a/crates/resolver/src/name_server/name_server_pool.rs
+++ b/crates/resolver/src/name_server/name_server_pool.rs
@@ -230,6 +230,7 @@ where
     type Error = ResolveError;
 
     fn send<R: Into<DnsRequest>>(&self, request: R) -> Self::Response {
+        tracing::debug!("Sending request");
         let opts = self.options.clone();
         let request = request.into();
         let datagram_conns = Arc::clone(&self.datagram_conns);


### PR DESCRIPTION
hickory-server sometimes fails to respond. There is something that blocks it, but right now, not sure what or why. Because of a lot of abstraction in the repo, it is difficult to pinpoint where problem might be, and the issue isn't reproducible. Hence sprinkling logs around send hoping to have more data to continue.