### PR TITLE
Bump rand version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1990,9 +1990,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.9.2"
+version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+checksum = "7ec095654a25171c2124e9e3393a930bddbffdc939556c914957a4c3e0a87166"
 dependencies = [
  "rand_chacha",
  "rand_core",


### PR DESCRIPTION
Bump rand version in regard to [security advisory ](https://rustsec.org/advisories/RUSTSEC-2026-0097)